### PR TITLE
add header guard

### DIFF
--- a/bench.h
+++ b/bench.h
@@ -1,3 +1,7 @@
+
+#ifdef BENCH
+#define BENCH
+
 #include <time.h>
 
 #ifdef CLOCK_MONOTONIC_RAW
@@ -17,3 +21,5 @@ static float cpu() {
   clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &tp);
   return tp.tv_sec + 1e-9 * tp.tv_nsec;
 }
+
+#endif


### PR DESCRIPTION
this allows compiling when multiple `#include "bench.h"` statements are used
